### PR TITLE
Upgrade to use Omniauth 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,28 +7,45 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (1.1.0)
+    faraday (1.5.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
+    faraday-patron (1.0.0)
     hashie (4.1.0)
-    jwt (2.2.2)
+    jwt (2.2.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    oauth2 (1.4.4)
+    oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.9.1)
+    omniauth (2.0.4)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-oauth2 (1.7.0)
+      rack-protection
+    omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
-      omniauth (~> 1.9)
+      omniauth (>= 1.9, < 3)
     rack (2.2.3)
-    ruby2_keywords (0.0.2)
+    rack-protection (2.1.0)
+      rack
+    ruby2_keywords (0.0.4)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## What's this do?

Clubhouse Story - Upgrade omniauth-microsoft_v2_auth #10910 

Updates our gem to use omniauth 2.0.4

## What's risky about it?
We could possibly break our MS Oauth in Special Sauce

## Testing Instructions
Visit staging2 and log out if you aren't already.
Log in using your MS credentials.
See that you are logged in and redirected to the bonus feed.
Celebrate that it isn't broken

